### PR TITLE
RFID nearly complete (^^!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ Dự án này tập trung vào việc tích hợp **RFID PN532** với **ESP32-S
    ```bash  
    git clone https://github.com/Lena-user/PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform.git  
    cd PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform  
-
 - Cài đặt PlatformIO (nếu chưa có):- Hướng dẫn cài đặt PlatformIO
-- Hoặc dùng lệnh để cài đặt trên VS Code:code --install-extension platformio.platformio-ide  
-
-
+- Hoặc dùng lệnh để cài đặt trên VS Code:
+    ```bash
+    code --install-extension platformio.platformio-ide  
 - Mở dự án với VS Code:- Mở VS Code và chọn File > Open Folder.
 - Chọn thư mục PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform.
 
@@ -54,16 +53,13 @@ PlatformIO_ESP32-S3 DevkitC1-N16R8_Platform/
 │── project_config.h    # Cấu hình dự án  
 
 ## 🔧 Cách sử dụng  
-
-Biên dịch và tải chương trình lên ESP32-S3:  
-```bash
-pio run --target upload '''
-
-Giám sát Serial để kiểm tra dữ liệu RFID:
-'''bash
-pio device monitor '''
-
-
+- Biên dịch và tải chương trình lên ESP32-S3:  
+    ```bash
+    pio run --target upload 
+- Giám sát Serial để kiểm tra dữ liệu RFID:
+    ```bash
+    pio device monitor
 ## 📜 Ghi chú
 Dự án này tập trung vào việc tích hợp RFID PN532 với ESP32-S3 bằng PlatformIO.
 Nếu bạn muốn mở rộng tính năng, hãy đảm bảo tuân theo cấu trúc thư mục hiện có
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Dự án này tập trung vào việc tích hợp **RFID PN532** với **ESP32-S
    git clone https://github.com/Lena-user/PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform.git  
    cd PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform  
 
-
 - Cài đặt PlatformIO (nếu chưa có):- Hướng dẫn cài đặt PlatformIO
 - Hoặc dùng lệnh để cài đặt trên VS Code:code --install-extension platformio.platformio-ide  
 
@@ -24,25 +23,25 @@ Dự án này tập trung vào việc tích hợp **RFID PN532** với **ESP32-S
 - Mở dự án với VS Code:- Mở VS Code và chọn File > Open Folder.
 - Chọn thư mục PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform.
 
+## 🔗 Kết nối ESP32-S3 với RFID PN532  
 
-🔗 Kết nối ESP32-S3 với RFID PN532
-🟢 I2C (Khuyến nghị)
-| Chân PN532 | Chân ESP32-S3 | Chức năng | 
-| VCC | 3.3V | Nguồn | 
-| GND | GND | Mass | 
-| SDA | GPIO14 | Dữ liệu I2C | 
-| SCL | GPIO13 | Clock I2C | 
+### 🟢 I2C (Khuyến nghị)  
+| Chân PN532 | Chân ESP32-S3 | Chức năng |  
+|-----------|-------------|------------|  
+| **VCC**  | **3.3V**   | Nguồn      |  
+| **GND**  | **GND**    | Mass       |  
+| **SDA**  | **GPIO14** | Dữ liệu I2C |  
+| **SCL**  | **GPIO13** | Clock I2C  |  
 
-
-🔵 SPI
-| Chân PN532 | Chân ESP32-S3 | Chức năng | 
-| VCC | 3.3V | Nguồn | 
-| GND | GND | Mass | 
-| SCK | GPIO18 | Clock SPI | 
-| MOSI | GPIO23 | Dữ liệu gửi | 
-| MISO | GPIO19 | Dữ liệu nhận | 
-| SS | GPIO5 | Chip Select | 
-
+### 🔵 SPI  
+| Chân PN532 | Chân ESP32-S3 | Chức năng |  
+|-----------|-------------|------------|  
+| **VCC**  | **3.3V**   | Nguồn      |  
+| **GND**  | **GND**    | Mass       |  
+| **SCK**  | **GPIO18** | Clock SPI  |  
+| **MOSI** | **GPIO23** | Dữ liệu gửi |  
+| **MISO** | **GPIO19** | Dữ liệu nhận |  
+| **SS**   | **GPIO5**  | Chip Select |  
 
 📂 Cấu trúc thư mục
 PlatformIO_ESP32-S3_DevkitC1-N16R8_Platform/  

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# PlatformIO ESP32-S3 DevkitC1-N16R8 - RFID PN532  
+
+## 📌 Giới thiệu  
+Dự án này tập trung vào việc tích hợp **RFID PN532** với **ESP32-S3 DevkitC1-N16R8**, giúp đọc và xử lý thẻ NFC một cách hiệu quả bằng **PlatformIO**.  
+
+## 🚀 Tính năng chính  
+- Hỗ trợ **RFID PN532** với giao tiếp **I2C/SPI/UART**.  
+- Đọc UID của thẻ NFC và xử lý dữ liệu.  
+- Ghi và đọc dữ liệu từ thẻ MIFARE.  
+- Quản lý bộ nhớ Flash và PSRAM tối ưu trên ESP32-S3.  
+- Dễ dàng mở rộng và tùy chỉnh theo nhu cầu.  
+
+## 🛠 Cách cài đặt  
+1. **Clone repository**:  
+   ```bash  
+   git clone https://github.com/Lena-user/PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform.git  
+   cd PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform  
+
+
+- Cài đặt PlatformIO (nếu chưa có):- Hướng dẫn cài đặt PlatformIO
+- Hoặc dùng lệnh để cài đặt trên VS Code:code --install-extension platformio.platformio-ide  
+
+
+- Mở dự án với VS Code:- Mở VS Code và chọn File > Open Folder.
+- Chọn thư mục PlatformIO_ESP32_S3_DevkitC1-N16R8_Platform.
+
+
+🔗 Kết nối ESP32-S3 với RFID PN532
+🟢 I2C (Khuyến nghị)
+| Chân PN532 | Chân ESP32-S3 | Chức năng | 
+| VCC | 3.3V | Nguồn | 
+| GND | GND | Mass | 
+| SDA | GPIO14 | Dữ liệu I2C | 
+| SCL | GPIO13 | Clock I2C | 
+
+
+🔵 SPI
+| Chân PN532 | Chân ESP32-S3 | Chức năng | 
+| VCC | 3.3V | Nguồn | 
+| GND | GND | Mass | 
+| SCK | GPIO18 | Clock SPI | 
+| MOSI | GPIO23 | Dữ liệu gửi | 
+| MISO | GPIO19 | Dữ liệu nhận | 
+| SS | GPIO5 | Chip Select | 
+
+
+📂 Cấu trúc thư mục
+PlatformIO_ESP32-S3_DevkitC1-N16R8_Platform/  
+│── .vscode/            # Cấu hình VS Code  
+│── include/            # Header files (PN532Reader.h, config.h)  
+│── lib/                # Thư viện tùy chỉnh  
+│── src/                # Mã nguồn chính (PN532Reader.cpp)  
+│── test/               # Kiểm thử  
+│── platformio.ini      # Cấu hình PlatformIO  
+│── project_config.h    # Cấu hình dự án  
+
+
+🔧 Cách sử dụng
+- Biên dịch và tải chương trình lên ESP32-S3:pio run --target upload  
+
+- Giám sát Serial để kiểm tra dữ liệu RFID:pio device monitor  
+
+
+📜 Ghi chú
+- Dự án này tập trung vào việc tích hợp RFID PN532 với ESP32-S3 bằng PlatformIO.
+- Nếu bạn muốn mở rộng tính năng, hãy đảm bảo tuân theo cấu trúc thư mục hiện có.

--- a/README.md
+++ b/README.md
@@ -44,33 +44,26 @@ Dự án này tập trung vào việc tích hợp **RFID PN532** với **ESP32-S
 | **SS**   | **GPIO5**  | Chip Select |  
 
 ## 📂 Cấu trúc thư mục  
-
-PlatformIO_ESP32-S3 DevkitC1-N16R8_Platform/
-│── .vscode/            # Cấu hình VS Code
-│── include/            # Header files (PN532Reader.h, config.h)
-│── lib/                # Thư viện tùy chỉnh
-│── src/                # Mã nguồn chính (PN532Reader.cpp)
-│── test/               # Kiểm thử
-│── platformio.ini      # Cấu hình PlatformIO
-│── project_config.h    # Cấu hình dự án
-
-Có vẻ như bạn cần chỉnh sửa một chút để đảm bảo đúng định dạng Markdown. Tôi thấy có một số khoảng cách thừa và thiếu dấu kết thúc trong phần khối mã. Dưới đây là phiên bản chuẩn hơn:
+PlatformIO_ESP32-S3 DevkitC1-N16R8_Platform/  
+│── .vscode/            # Cấu hình VS Code  
+│── include/            # Header files (PN532Reader.h, config.h)  
+│── lib/                # Thư viện tùy chỉnh  
+│── src/                # Mã nguồn chính (PN532Reader.cpp)  
+│── test/               # Kiểm thử  
+│── platformio.ini      # Cấu hình PlatformIO  
+│── project_config.h    # Cấu hình dự án  
 
 ## 🔧 Cách sử dụng  
 
-**Biên dịch và tải chương trình lên ESP32-S3:**  
+Biên dịch và tải chương trình lên ESP32-S3:  
 ```bash
-pio run --target upload
+pio run --target upload '''
 
-
-**Giám sát Serial để kiểm tra dữ liệu RFID:**
+Giám sát Serial để kiểm tra dữ liệu RFID:
 '''bash
-pio device monitor
+pio device monitor '''
 
 
-**📜 Ghi chú**
+## 📜 Ghi chú
 Dự án này tập trung vào việc tích hợp RFID PN532 với ESP32-S3 bằng PlatformIO.
-Nếu bạn muốn mở rộng tính năng, hãy đảm bảo tuân theo cấu trúc thư mục hiện có.
- 
-
-
+Nếu bạn muốn mở rộng tính năng, hãy đảm bảo tuân theo cấu trúc thư mục hiện có

--- a/README.md
+++ b/README.md
@@ -43,23 +43,34 @@ Dự án này tập trung vào việc tích hợp **RFID PN532** với **ESP32-S
 | **MISO** | **GPIO19** | Dữ liệu nhận |  
 | **SS**   | **GPIO5**  | Chip Select |  
 
-📂 Cấu trúc thư mục
-PlatformIO_ESP32-S3_DevkitC1-N16R8_Platform/  
-│── .vscode/            # Cấu hình VS Code  
-│── include/            # Header files (PN532Reader.h, config.h)  
-│── lib/                # Thư viện tùy chỉnh  
-│── src/                # Mã nguồn chính (PN532Reader.cpp)  
-│── test/               # Kiểm thử  
-│── platformio.ini      # Cấu hình PlatformIO  
-│── project_config.h    # Cấu hình dự án  
+## 📂 Cấu trúc thư mục  
+
+PlatformIO_ESP32-S3 DevkitC1-N16R8_Platform/
+│── .vscode/            # Cấu hình VS Code
+│── include/            # Header files (PN532Reader.h, config.h)
+│── lib/                # Thư viện tùy chỉnh
+│── src/                # Mã nguồn chính (PN532Reader.cpp)
+│── test/               # Kiểm thử
+│── platformio.ini      # Cấu hình PlatformIO
+│── project_config.h    # Cấu hình dự án
+
+Có vẻ như bạn cần chỉnh sửa một chút để đảm bảo đúng định dạng Markdown. Tôi thấy có một số khoảng cách thừa và thiếu dấu kết thúc trong phần khối mã. Dưới đây là phiên bản chuẩn hơn:
+
+## 🔧 Cách sử dụng  
+
+**Biên dịch và tải chương trình lên ESP32-S3:**  
+```bash
+pio run --target upload
 
 
-🔧 Cách sử dụng
-- Biên dịch và tải chương trình lên ESP32-S3:pio run --target upload  
+**Giám sát Serial để kiểm tra dữ liệu RFID:**
+'''bash
+pio device monitor
 
-- Giám sát Serial để kiểm tra dữ liệu RFID:pio device monitor  
+
+**📜 Ghi chú**
+Dự án này tập trung vào việc tích hợp RFID PN532 với ESP32-S3 bằng PlatformIO.
+Nếu bạn muốn mở rộng tính năng, hãy đảm bảo tuân theo cấu trúc thư mục hiện có.
+ 
 
 
-📜 Ghi chú
-- Dự án này tập trung vào việc tích hợp RFID PN532 với ESP32-S3 bằng PlatformIO.
-- Nếu bạn muốn mở rộng tính năng, hãy đảm bảo tuân theo cấu trúc thư mục hiện có.

--- a/include/PN532Reader.h
+++ b/include/PN532Reader.h
@@ -1,0 +1,28 @@
+#ifndef PN532READER_H
+#define PN532READER_H
+
+#include <Wire.h>
+#include <Adafruit_PN532.h>
+
+class PN532Reader
+{
+private:
+    Adafruit_PN532 nfc;
+    uint8_t PN532_SDA;
+    uint8_t PN532_SCL;
+
+public:
+    PN532Reader(uint8_t sda, uint8_t scl);
+    void begin();
+    bool scanCard(uint8_t *uid, uint8_t &uidLength);
+    void printUID(uint8_t *uid, uint8_t uidLength);
+    bool authenticateBlock(uint8_t block, uint8_t *key, uint8_t *uid, uint8_t uidLength);
+    bool writeBlock(uint8_t block, uint8_t *data);                          // Ghi từ mảng uint8_t[]
+    bool writeBlock(uint8_t block, String data);                            // Ghi từ String
+    bool writeBlock(uint8_t block, const char *data);                       // Ghi từ mảng ký tự char*
+    bool writeBlock(uint8_t startBlock, uint8_t *data, uint8_t dataLength); // Ghi nhiều block
+    void readBlock(uint8_t block, uint8_t *data);
+    std::string readBlockAsString(uint8_t block); // Đọc dữ liệu từ block
+};
+
+#endif // PN532READER_H

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,14 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+// Cấu hình giao tiếp I2C
+#define SDA_PIN 14
+#define SCL_PIN 13
+
+// Cấu hình Serial Monitor
+#define SERIAL_BAUD 115200
+
+// Cấu hình thời gian quét NFC
+#define NFC_SCAN_DELAY 2000  // 2 giây giữa mỗi lần quét
+
+#endif // CONFIG_H

--- a/include/main.h
+++ b/include/main.h
@@ -1,1 +1,15 @@
+#ifndef MAIN_H
+#define MAIN_H
+
 #include <Arduino.h>
+#include <string> // Thư viện string
+#include <sstream> // Thư viện stringstream
+
+// Private Include
+#include "PN532Reader.h" // Thư viện PN532
+#include "config.h" // Thư viện cấu hình
+
+extern PN532Reader nfcReader; // Khai báo đối tượng PN532Reader
+
+
+#endif // MAIN_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ build_flags =
     -include project_config.h
 
 lib_deps =
+    adafruit/Adafruit PN532@^1.3.0
 
 lib_extra_dirs =
     lib

--- a/src/PN532Reader.cpp
+++ b/src/PN532Reader.cpp
@@ -1,0 +1,149 @@
+#include "PN532Reader.h"
+
+// Khởi tạo PN532 với SDA và SCL
+// SDA: GPIO14, SCL: GPIO13
+PN532Reader::PN532Reader(uint8_t sda, uint8_t scl) : nfc(sda, scl), PN532_SDA(sda), PN532_SCL(scl) {}
+
+// Khởi tạo PN532
+void PN532Reader::begin()
+{
+    Wire.begin(PN532_SDA, PN532_SCL);
+    nfc.begin();
+    nfc.SAMConfig();
+    Serial.println("PN532 Initialized and Ready!");
+}
+
+// Quét thẻ NFC
+// uid[]: Mảng chứa UID của thẻ
+// uidLength: Kích thước UID
+// Trả về true nếu quét thành công, false nếu không có thẻ nào được quét    
+bool PN532Reader::scanCard(uint8_t *uid, uint8_t &uidLength)
+{
+    if (nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength))
+    {
+        return true;
+    }
+    return false;
+}
+
+// In UID của thẻ ra Serial Monitor
+// uid[]: Mảng chứa UID của thẻ
+// uidLength: Kích thước UID
+// Ví dụ: UID = 0xDE, 0xAD, 0xBE, 0xEF
+// In ra: Card UID: DE:AD:BE:EF
+void PN532Reader::printUID(uint8_t *uid, uint8_t uidLength)
+{
+    Serial.print("Card UID: ");
+    for (uint8_t i = 0; i < uidLength; i++)
+    {
+        Serial.printf("%02X", uid[i]);
+        if (i < uidLength - 1)
+            Serial.print(":");
+    }
+    Serial.println();
+}
+
+// Xác thực block với key A (key[0] = 0xFF, key[1] = 0xFF, key[2] = 0xFF, key[3] = 0xFF, key[4] = 0xFF, key[5] = 0xFF)
+// uid[]: Mảng chứa UID của thẻ
+// uidLength: Kích thước UID
+// block: Block cần xác thực (0-15)
+// key: Mảng chứa key A (6 byte)
+// Trả về true nếu xác thực thành công, false nếu không xác thực được
+bool PN532Reader::authenticateBlock(uint8_t block, uint8_t *key, uint8_t *uid, uint8_t uidLength)
+{
+    return nfc.mifareclassic_AuthenticateBlock(uid, uidLength, block, 0, key);
+}
+
+// Ghi dữ liệu từ mảng uint8_t[]
+// Dữ liệu ghi vào block sẽ được lưu trong mảng data[] với kích thước 16 byte
+// block: Block cần ghi (0-15)
+// data[]: Mảng chứa dữ liệu cần ghi (16 byte)
+// Trả về true nếu ghi thành công, false nếu không ghi được
+bool PN532Reader::writeBlock(uint8_t block, uint8_t *data)
+{
+    return nfc.mifareclassic_WriteDataBlock(block, data);
+}
+
+// Ghi dữ liệu từ String
+bool PN532Reader::writeBlock(uint8_t block, String data)
+{
+    uint8_t buffer[16];
+    memset(buffer, 0, 16); // Xóa dữ liệu cũ
+    data.getBytes(buffer, 16);
+    return writeBlock(block, buffer);
+}
+
+// Ghi dữ liệu từ mảng ký tự const char*
+bool PN532Reader::writeBlock(uint8_t block, const char *data)
+{
+    uint8_t buffer[16];
+    memset(buffer, 0, 16);
+    strncpy((char *)buffer, data, 16);
+    return writeBlock(block, buffer);
+}
+
+// Ghi dữ liệu dài hơn 16 byte vào nhiều block liên tiếp
+bool PN532Reader::writeBlock(uint8_t startBlock, uint8_t *data, uint8_t dataLength)
+{
+    uint8_t block = startBlock;
+    uint8_t buffer[16];
+
+    for (uint8_t i = 0; i < dataLength; i += 16)
+    {
+        memset(buffer, 0, 16);
+        memcpy(buffer, &data[i], (dataLength - i >= 16) ? 16 : dataLength - i);
+
+        if (!writeBlock(block, buffer))
+        {
+            Serial.print("Failed to write block ");
+            Serial.println(block);
+            return false;
+        }
+        block++;
+    }
+    return true;
+}
+
+// Đọc dữ liệu từ block
+// Dữ liệu đọc được sẽ được lưu vào mảng data[] với kích thước 16 byte
+// block: Block cần đọc (0-15)
+// data[]: Mảng chứa dữ liệu đọc được (16 byte)
+// Trả về true nếu đọc thành công, false nếu không đọc được
+void PN532Reader::readBlock(uint8_t block, uint8_t *data)
+{
+    if (nfc.mifareclassic_ReadDataBlock(block, data))
+    {
+        Serial.print("Data from block ");
+        Serial.print(block);
+        Serial.print(": ");
+
+        // Hiển thị dữ liệu dạng chuỗi
+        Serial.print("[ ");
+        for (int i = 0; i < 16; i++)
+        {
+            Serial.print((char)data[i]); // Chuyển đổi dữ liệu từ uint8_t về char
+        }
+        Serial.println(" ]");
+
+    }
+    else
+    {
+        Serial.println("Failed to read block.");
+    }
+}
+
+
+std::string PN532Reader::readBlockAsString(uint8_t block)
+{
+    uint8_t data[16];
+    std::string result = "";
+
+    if (nfc.mifareclassic_ReadDataBlock(block, data))
+    {
+        for (int i = 0; i < 16; i++)
+        {
+            result += (char)data[i];
+        }
+    }
+    return result;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,47 @@
 #include "main.h"
 
+PN532Reader nfcReader(SDA_PIN, SCL_PIN); // Khởi tạo PN532 với SDA = GPIO14, SCL = GPIO13
+
 void setup()
 {
     Serial.begin(115200);
-    Serial.print("Hello World! ");
+    nfcReader.begin(); // Khởi tạo PN532
+    Serial.println("PN532 Initialized and Ready!");
 }
 
 void loop()
 {
-    Serial.println("Hello from ESP32!");
-    delay(1000); // Delay 1 giây
+    Serial.println("Waiting for NFC card... ");
+    uint8_t uid[7];        // Mảng chứa UID của thẻ
+    uint8_t uidLength = 0; // Kích thước UID
+    if (nfcReader.scanCard(uid, uidLength))
+    {                                                          // Quét thẻ NFC
+        nfcReader.printUID(uid, uidLength);                    // In UID của thẻ ra Serial Monitor
+        uint8_t key[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}; // Key A (6 byte)
+        uint8_t block = 4;                                     // Block cần ghi (0-15)
+        if (nfcReader.authenticateBlock(block, key, uid, uidLength))
+        { // Xác thực block với key A
+            Serial.println("Authentication successful!");
+            if (nfcReader.writeBlock(block, "Love Mika!!!"))
+            { // Ghi dữ liệu vào block
+                Serial.println("Data written successfully!");
+                std::string data = nfcReader.readBlockAsString(block); // Đọc dữ liệu từ block
+                Serial.print("Data from block: ");
+                Serial.println(data.c_str()); // In dữ liệu ra Serial Monitor
+            }
+            else
+            {
+                Serial.println("Failed to write data!");
+            }
+        }
+        else
+        {
+            Serial.println("Authentication failed!");
+        }
+    }
+    else
+    {
+        Serial.println("No NFC card detected!");
+    }
+    delay(NFC_SCAN_DELAY);
 }


### PR DESCRIPTION
### Title: Add PN532Reader NFC Support

#### Description:
Tôi đã viết một lớp `PN532Reader` để hỗ trợ giao tiếp với module PN532 thông qua I2C (SDA - GPIO14, SCL - GPIO13). Lớp này hỗ trợ quét thẻ NFC, xác thực block, đọc/ghi dữ liệu, và in UID của thẻ.

#### Các thay đổi:
- Thêm `PN532Reader.h` và `PN532Reader.cpp`
- Hỗ trợ quét thẻ NFC với `scanCard()`
- Hiển thị UID của thẻ bằng `printUID()`
- Xác thực block với `authenticateBlock()`
- Đọc và ghi dữ liệu vào block bằng `readBlock()` và `writeBlock()`

#### Cách sử dụng:
```cpp
#include "PN532Reader.h"

PN532Reader nfcReader(14, 13);

void setup() {
    Serial.begin(115200);
    nfcReader.begin();
}

void loop() {
    uint8_t uid[7];
    uint8_t uidLength;

    if (nfcReader.scanCard(uid, uidLength)) {
        Serial.println("Card detected!");
        nfcReader.printUID(uid, uidLength);
    } else {
        Serial.println("No card detected.");
    }

    delay(1000);
}